### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Model Context Protocol (MCP) を使用して、棒読みちゃん（ゆっくりボイス）による音声読み上げ機能をAIアシスタントに提供するサーバーです。Node.js/TypeScriptで実装されています。
 
+<a href="https://glama.ai/mcp/servers/@uraoz/bouyomi-mcp-nodejs">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@uraoz/bouyomi-mcp-nodejs/badge" alt="Bouyomi-chan Server MCP server" />
+</a>
+
 ## 概要
 
 このサーバーは、Claude などのAIアシスタントから「棒読みちゃん」の読み上げ機能を利用できるようにするMCPサーバーです。AIモデルが理解しやすいインターフェースを提供し、テキストを音声に変換する機能を実現します。


### PR DESCRIPTION
This PR adds a badge for the [Bouyomi-chan MCP Server](https://glama.ai/mcp/servers/@uraoz/bouyomi-mcp-nodejs) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@uraoz/bouyomi-mcp-nodejs">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@uraoz/bouyomi-mcp-nodejs/badge" alt="Bouyomi-chan Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.